### PR TITLE
Bug/apps 2005 enforce enrollment status

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,6 +75,9 @@
             android:name=".services.usage.UsageEventsService"
             android:exported="true"
             android:permission="android.permission.BIND_JOB_SERVICE" />
+        <service
+            android:name=".services.status.ParticipationStatusMonitoringService"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
 
         <meta-data
             android:name="io.fabric.ApiKey"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,6 +77,7 @@
             android:permission="android.permission.BIND_JOB_SERVICE" />
         <service
             android:name=".services.status.ParticipationStatusMonitoringService"
+            android:exported="true"
             android:permission="android.permission.BIND_JOB_SERVICE" />
 
         <meta-data

--- a/app/src/main/java/com/openlattice/chronicle/MainActivity.kt
+++ b/app/src/main/java/com/openlattice/chronicle/MainActivity.kt
@@ -7,12 +7,14 @@ import android.os.Looper
 import android.support.v7.app.AppCompatActivity
 import android.widget.TextView
 import com.crashlytics.android.Crashlytics
+import com.openlattice.chronicle.data.ParticipationStatus
 import com.openlattice.chronicle.preferences.EnrollmentSettings
 import com.openlattice.chronicle.services.notifications.createNotificationChannel
 import com.openlattice.chronicle.services.notifications.scheduleNotificationJobService
 import com.openlattice.chronicle.services.upload.getLastUpload
 import com.openlattice.chronicle.services.upload.scheduleUploadJob
 import com.openlattice.chronicle.services.usage.scheduleUsageMonitoringJob
+import com.openlattice.chronicle.services.status.scheduleParticipationStatusJob
 import io.fabric.sdk.android.Fabric
 
 
@@ -34,17 +36,15 @@ class MainActivity : AppCompatActivity() {
             if (enrollment.enrolled) {
                 val studyIdText = findViewById<TextView>(R.id.studyId)
                 val participantIdText = findViewById<TextView>(R.id.participantId)
+                studyIdText.text = enrollment.getStudyId().toString()
+                participantIdText.text = enrollment.getParticipantId()
 
-                val studyId = enrollment.getStudyId().toString()
-                val participantId = enrollment.getParticipantId()
-
-                studyIdText.text = studyId
-                participantIdText.text = participantId
-
-                scheduleUploadJob(this)
-                scheduleUsageMonitoringJob(this)
+                if (enrollment.getParticipationStatus() == ParticipationStatus.ENROLLED) {
+                    scheduleUploadJob(this)
+                    scheduleUsageMonitoringJob(this)
+                }
                 scheduleNotificationJobService(this)
-
+                scheduleParticipationStatusJob(this)
                 handler.post(this::updateLastUpload)
 
             } else {

--- a/app/src/main/java/com/openlattice/chronicle/constants/Jobs.kt
+++ b/app/src/main/java/com/openlattice/chronicle/constants/Jobs.kt
@@ -1,0 +1,8 @@
+package com.openlattice.chronicle.constants
+
+enum class Jobs (val id: Int) {
+    UPLOAD_JOB_ID(0),
+    NOTIFICATION_JOB_ID(1),
+    MONITOR_PARTICIPATION_STATUS_JOB_ID(2),
+    MONITOR_USAGE_JOB_ID(3)
+}

--- a/app/src/main/java/com/openlattice/chronicle/preferences/EnrollmentSettings.kt
+++ b/app/src/main/java/com/openlattice/chronicle/preferences/EnrollmentSettings.kt
@@ -19,6 +19,7 @@ const val NOTIFICATIONS_ENABLED = "notificationsEnabled"
 const val STUDY_ID = "studyId"
 const val PARTICIPATION_STATUS = "participationStatus"
 const val PROPERTY_TYPE_IDS = "com.openlattice.PropertyTypeIds"
+
 val INVALID_STUDY_ID = UUID(0, 0)
 
 class EnrollmentSettings(private val context: Context) {
@@ -116,4 +117,3 @@ fun setCrashlyticsUser(studyId: UUID, participantId: String, deviceId: String) {
     Crashlytics.setUserEmail("$participantId@$studyId")
     Crashlytics.setUserName(deviceId)
 }
-

--- a/app/src/main/java/com/openlattice/chronicle/receivers/lifecycle/StartOnBoot.kt
+++ b/app/src/main/java/com/openlattice/chronicle/receivers/lifecycle/StartOnBoot.kt
@@ -6,6 +6,9 @@ import android.content.Intent
 import android.content.Intent.ACTION_BOOT_COMPLETED
 import android.util.Log
 import com.openlattice.chronicle.services.notifications.scheduleNotificationJobService
+import com.openlattice.chronicle.data.ParticipationStatus
+import com.openlattice.chronicle.preferences.EnrollmentSettings
+import com.openlattice.chronicle.services.status.scheduleParticipationStatusJob
 import com.openlattice.chronicle.services.upload.scheduleUploadJob
 import com.openlattice.chronicle.services.usage.scheduleUsageMonitoringJob
 
@@ -13,16 +16,22 @@ class StartOnBoot : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         if (context != null && intent != null) {
             if (intent.action.equals(ACTION_BOOT_COMPLETED)) {
-                scheduleUsageMonitoringJob(context)
-                Log.i(javaClass.canonicalName, "Started usage service at boot.")
-                scheduleUploadJob(context)
-                Log.i(javaClass.canonicalName, "Scheduled upload job at boot.")
+                val settings = EnrollmentSettings(context)
+
+                if (settings.getParticipationStatus() == ParticipationStatus.ENROLLED) {
+                    scheduleUsageMonitoringJob(context)
+                    Log.i(javaClass.canonicalName, "Started usage service at boot.")
+                    scheduleUploadJob(context)
+                    Log.i(javaClass.canonicalName, "Scheduled upload job at boot.")
+                }
                 scheduleNotificationJobService(context)
                 Log.i(javaClass.name, "Scheduled notification service at boot")
+
+                scheduleParticipationStatusJob(context)
+                Log.i(javaClass.name, "Scheduled participation status service at boot")
             }
         } else {
             Log.e(javaClass.canonicalName, "Unable to start Usage Service at Boot.")
         }
     }
 }
-

--- a/app/src/main/java/com/openlattice/chronicle/receivers/lifecycle/StartOnBoot.kt
+++ b/app/src/main/java/com/openlattice/chronicle/receivers/lifecycle/StartOnBoot.kt
@@ -5,9 +5,9 @@ import android.content.Context
 import android.content.Intent
 import android.content.Intent.ACTION_BOOT_COMPLETED
 import android.util.Log
-import com.openlattice.chronicle.services.notifications.scheduleNotificationJobService
 import com.openlattice.chronicle.data.ParticipationStatus
 import com.openlattice.chronicle.preferences.EnrollmentSettings
+import com.openlattice.chronicle.services.notifications.scheduleNotificationJobService
 import com.openlattice.chronicle.services.status.scheduleParticipationStatusJob
 import com.openlattice.chronicle.services.upload.scheduleUploadJob
 import com.openlattice.chronicle.services.usage.scheduleUsageMonitoringJob
@@ -17,16 +17,16 @@ class StartOnBoot : BroadcastReceiver() {
         if (context != null && intent != null) {
             if (intent.action.equals(ACTION_BOOT_COMPLETED)) {
                 val settings = EnrollmentSettings(context)
-
                 if (settings.getParticipationStatus() == ParticipationStatus.ENROLLED) {
                     scheduleUsageMonitoringJob(context)
                     Log.i(javaClass.canonicalName, "Started usage service at boot.")
+
                     scheduleUploadJob(context)
                     Log.i(javaClass.canonicalName, "Scheduled upload job at boot.")
                 }
                 scheduleNotificationJobService(context)
                 Log.i(javaClass.name, "Scheduled notification service at boot")
-
+                
                 scheduleParticipationStatusJob(context)
                 Log.i(javaClass.name, "Scheduled participation status service at boot")
             }

--- a/app/src/main/java/com/openlattice/chronicle/services/notifications/NotificationsService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/notifications/NotificationsService.kt
@@ -17,6 +17,7 @@ import android.util.Log
 import com.crashlytics.android.Crashlytics
 import com.openlattice.chronicle.ChronicleStudyApi
 import com.openlattice.chronicle.R
+import com.openlattice.chronicle.constants.Jobs.NOTIFICATION_JOB_ID
 import com.openlattice.chronicle.data.ParticipationStatus
 import com.openlattice.chronicle.preferences.EnrollmentSettings
 import com.openlattice.chronicle.receivers.lifecycle.NotificationsReceiver
@@ -29,7 +30,6 @@ import java.util.*
 import java.util.concurrent.Executors
 
 const val CHANNEL_ID = "Chronicle"
-const val NOTIFICATION_JOB_ID = 11;
 const val NOTIFICATION_PERIOD_MILLIS = 24 * 60 * 60 * 1000L
 const val LAST_NOTIFICATION_SETTING = "last_notification"
 
@@ -148,9 +148,9 @@ fun getLastNotificationDate(context: Context) :String {
 }
 
 fun scheduleNotificationJobService(context: Context) {
-    if (!isJobServiceScheduled(context, NOTIFICATION_JOB_ID)) {
+    if (!isJobServiceScheduled(context, NOTIFICATION_JOB_ID.id)) {
         val componentName = ComponentName(context, NotificationsService::class.java)
-        val jobBuilder = JobInfo.Builder(NOTIFICATION_JOB_ID, componentName)
+        val jobBuilder = JobInfo.Builder(NOTIFICATION_JOB_ID.id, componentName)
         jobBuilder.setPersisted(true)
         jobBuilder.setPeriodic(NOTIFICATION_PERIOD_MILLIS)
         jobBuilder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)

--- a/app/src/main/java/com/openlattice/chronicle/services/status/ParticipationStatusMonitoringService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/status/ParticipationStatusMonitoringService.kt
@@ -43,12 +43,12 @@ class ParticipationStatusMonitoringService : JobService() {
     override fun onStartJob(parameters: JobParameters?): Boolean {
         Log.i(javaClass.name, "Participation status service initialized")
 
-        val enrollmentSettings = EnrollmentSettings(applicationContext)
-        val studyId :UUID = enrollmentSettings.getStudyId()
-        val participantId :String = enrollmentSettings.getParticipantId()
-
         executor.execute {
+            val enrollmentSettings = EnrollmentSettings(applicationContext)
+            val studyId :UUID = enrollmentSettings.getStudyId()
+            val participantId :String = enrollmentSettings.getParticipantId()
             var participationStatus = enrollmentSettings.getParticipationStatus()
+            
             try {
                 participationStatus = chronicleStudyApi.getParticipationStatus(studyId, participantId)
             } catch (e :Exception) {

--- a/app/src/main/java/com/openlattice/chronicle/services/status/ParticipationStatusMonitoringService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/status/ParticipationStatusMonitoringService.kt
@@ -35,7 +35,8 @@ class ParticipationStatusMonitoringService : JobService() {
     }
     override fun onStopJob(p0: JobParameters?): Boolean {
         Log.i(javaClass.name, "Participation status service stopped")
-        return true
+        executor.shutdown()
+        return true // reschedule the job
     }
 
     override fun onStartJob(parameters: JobParameters?): Boolean {
@@ -52,7 +53,7 @@ class ParticipationStatusMonitoringService : JobService() {
                 Log.e(javaClass.name, "Error retrieving participation status")
                 participationStatus = ParticipationStatus.UNKNOWN
             }
-            Log.e(javaClass.name, "Participation status: $participationStatus")
+            Log.i(javaClass.name, "Participation status: $participationStatus")
             enrollmentSettings.setParticipationStatus(participationStatus)
 
             if (participationStatus == ParticipationStatus.ENROLLED) {
@@ -62,7 +63,7 @@ class ParticipationStatusMonitoringService : JobService() {
                 cancelUsageMonitoringJobScheduler(this)
                 cancelUploadJobScheduler(this)
             }
-            jobFinished(parameters, true)
+            jobFinished(parameters, false)
         }
         return true
     }

--- a/app/src/main/java/com/openlattice/chronicle/services/status/ParticipationStatusMonitoringService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/status/ParticipationStatusMonitoringService.kt
@@ -1,0 +1,76 @@
+package com.openlattice.chronicle.services.status
+
+import android.app.job.JobInfo
+import android.app.job.JobParameters
+import android.app.job.JobScheduler
+import android.app.job.JobService
+import android.content.ComponentName
+import android.content.Context
+import android.os.AsyncTask
+import android.util.Log
+import com.openlattice.chronicle.ChronicleStudyApi
+import com.openlattice.chronicle.data.ParticipationStatus
+import com.openlattice.chronicle.preferences.EnrollmentSettings
+import com.openlattice.chronicle.services.upload.PRODUCTION
+import com.openlattice.chronicle.services.upload.cancelUploadJobScheduler
+import com.openlattice.chronicle.services.upload.createRetrofitAdapter
+import com.openlattice.chronicle.services.upload.scheduleUploadJob
+import com.openlattice.chronicle.services.usage.cancelUsageMonitoringJobScheduler
+import com.openlattice.chronicle.services.usage.scheduleUsageMonitoringJob
+import java.lang.Exception
+import java.util.*
+
+const val STATUS_CHECK_PERIOD_MILLIS = 15 * 60 * 1000L
+
+class ParticipationStatusMonitoringService : JobService() {
+    override fun onStopJob(p0: JobParameters?): Boolean {
+        return true
+    }
+
+    override fun onStartJob(p0: JobParameters?): Boolean {
+        val enrollmentSettings = EnrollmentSettings(applicationContext)
+        val studyId :UUID = enrollmentSettings.getStudyId()
+        val participantId :String = enrollmentSettings.getParticipantId()
+
+        EnrollmentStatusTask(studyId, participantId, enrollmentSettings, applicationContext).execute()
+        return true
+    }
+
+    class EnrollmentStatusTask(private val studyId :UUID, private val participantId :String, private val enrollmentSettings: EnrollmentSettings, private val context :Context) : AsyncTask<Objects, Void, ParticipationStatus>() {
+        private val chronicleStudyApi = createRetrofitAdapter(PRODUCTION).create(ChronicleStudyApi::class.java)
+
+        override fun doInBackground(vararg params: Objects?): ParticipationStatus {
+            val participationStatus: ParticipationStatus
+            try {
+                participationStatus = chronicleStudyApi.getParticipationStatus(studyId, participantId)
+            } catch (e :Exception) {
+                return ParticipationStatus.UNKNOWN
+            }
+            return participationStatus
+        }
+
+        override fun onPostExecute(result: ParticipationStatus) {
+            super.onPostExecute(result)
+            Log.i(javaClass.name, "Status of participant $participantId in study ${studyId}: $result")
+            enrollmentSettings.setParticipationStatus(result)
+
+            if (result == ParticipationStatus.ENROLLED) {
+                scheduleUploadJob(context)
+                scheduleUsageMonitoringJob(context)
+            } else {
+                cancelUsageMonitoringJobScheduler(context)
+                cancelUploadJobScheduler(context)
+            }
+        }
+    }
+}
+
+fun scheduleParticipationStatusJob(context :Context) {
+    val serviceComponent = ComponentName(context, ParticipationStatusMonitoringService::class.java)
+    val jobBuilder = JobInfo.Builder(0, serviceComponent)
+    jobBuilder.setPersisted(true)
+    jobBuilder.setPeriodic(STATUS_CHECK_PERIOD_MILLIS)
+    jobBuilder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+    val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
+    jobScheduler.schedule(jobBuilder.build())
+}

--- a/app/src/main/java/com/openlattice/chronicle/services/status/ParticipationStatusMonitoringService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/status/ParticipationStatusMonitoringService.kt
@@ -38,7 +38,7 @@ class ParticipationStatusMonitoringService : JobService() {
         return true
     }
 
-    override fun onStartJob(p0: JobParameters?): Boolean {
+    override fun onStartJob(parameters: JobParameters?): Boolean {
         Log.i(javaClass.name, "Participation status service initialized")
         val enrollmentSettings = EnrollmentSettings(applicationContext)
         val studyId :UUID = enrollmentSettings.getStudyId()
@@ -52,6 +52,7 @@ class ParticipationStatusMonitoringService : JobService() {
                 Log.e(javaClass.name, "Error retrieving participation status")
                 participationStatus = ParticipationStatus.UNKNOWN
             }
+            Log.e(javaClass.name, "Participation status: $participationStatus")
             enrollmentSettings.setParticipationStatus(participationStatus)
 
             if (participationStatus == ParticipationStatus.ENROLLED) {
@@ -61,6 +62,7 @@ class ParticipationStatusMonitoringService : JobService() {
                 cancelUsageMonitoringJobScheduler(this)
                 cancelUploadJobScheduler(this)
             }
+            jobFinished(parameters, true)
         }
         return true
     }

--- a/app/src/main/java/com/openlattice/chronicle/services/status/ParticipationStatusMonitoringService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/status/ParticipationStatusMonitoringService.kt
@@ -13,6 +13,7 @@ import com.openlattice.chronicle.ChronicleStudyApi
 import com.openlattice.chronicle.data.ParticipationStatus
 import com.openlattice.chronicle.preferences.EnrollmentSettings
 import com.openlattice.chronicle.services.upload.PRODUCTION
+import com.openlattice.chronicle.constants.Jobs.MONITOR_PARTICIPATION_STATUS_JOB_ID
 import com.openlattice.chronicle.services.upload.cancelUploadJobScheduler
 import com.openlattice.chronicle.services.upload.createRetrofitAdapter
 import com.openlattice.chronicle.services.upload.scheduleUploadJob
@@ -73,7 +74,7 @@ class ParticipationStatusMonitoringService : JobService() {
 
 fun scheduleParticipationStatusJob(context :Context) {
     val serviceComponent = ComponentName(context, ParticipationStatusMonitoringService::class.java)
-    val jobBuilder = JobInfo.Builder(0, serviceComponent)
+    val jobBuilder = JobInfo.Builder(MONITOR_PARTICIPATION_STATUS_JOB_ID.id, serviceComponent)
     jobBuilder.setPersisted(true)
     jobBuilder.setPeriodic(STATUS_CHECK_PERIOD_MILLIS)
     jobBuilder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)

--- a/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
@@ -34,7 +34,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-const val PRODUCTION = "http://10.0.2.2:8081"
+const val PRODUCTION = "https://api.openlattice.com/"
 const val BATCH_SIZE = 100 // 24 * 60 * 60 / 5 //17280
 const val LAST_UPDATED_SETTING = "com.openlattice.chronicle.upload.LastUpdated"
 const val UPLOAD_PERIOD_MILLIS = 15 * 60 * 1000L

--- a/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
@@ -34,10 +34,11 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-const val PRODUCTION = "https://api.openlattice.com/"
+const val PRODUCTION = "http://10.0.2.2:8081"
 const val BATCH_SIZE = 100 // 24 * 60 * 60 / 5 //17280
 const val LAST_UPDATED_SETTING = "com.openlattice.chronicle.upload.LastUpdated"
 const val UPLOAD_PERIOD_MILLIS = 15 * 60 * 1000L
+const val UPLOAD_JOB_ID = 5;
 
 class UploadJobService : JobService() {
     private val executor = Executors.newSingleThreadExecutor()
@@ -158,11 +159,9 @@ fun createRetrofitAdapter(baseUrl: String): Retrofit {
     return decorateWithRhizomeFactories(createBaseChronicleRetrofitBuilder(baseUrl, httpClient)).build()
 }
 
-const val UPLOAD_JOB_ID = 5;
-
 fun scheduleUploadJob(context: Context) {
     val serviceComponent = ComponentName(context, UploadJobService::class.java)
-    val jobBuilder = JobInfo.Builder(0, serviceComponent)
+    val jobBuilder = JobInfo.Builder(UPLOAD_JOB_ID, serviceComponent)
     jobBuilder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
     jobBuilder.setPeriodic(UPLOAD_PERIOD_MILLIS)
     jobBuilder.setPersisted(true)

--- a/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
@@ -15,6 +15,7 @@ import com.google.common.base.Optional
 import com.google.common.base.Stopwatch
 import com.openlattice.chronicle.ChronicleApi
 import com.openlattice.chronicle.ChronicleStudyApi
+import com.openlattice.chronicle.data.ParticipationStatus
 import com.openlattice.chronicle.preferences.EnrollmentSettings
 import com.openlattice.chronicle.preferences.getDevice
 import com.openlattice.chronicle.preferences.getDeviceId
@@ -157,6 +158,8 @@ fun createRetrofitAdapter(baseUrl: String): Retrofit {
     return decorateWithRhizomeFactories(createBaseChronicleRetrofitBuilder(baseUrl, httpClient)).build()
 }
 
+const val UPLOAD_JOB_ID = 5;
+
 fun scheduleUploadJob(context: Context) {
     val serviceComponent = ComponentName(context, UploadJobService::class.java)
     val jobBuilder = JobInfo.Builder(0, serviceComponent)
@@ -165,5 +168,10 @@ fun scheduleUploadJob(context: Context) {
     jobBuilder.setPersisted(true)
     val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
     jobScheduler.schedule(jobBuilder.build())
+}
+
+fun cancelUploadJobScheduler (context: Context) {
+    val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
+    jobScheduler.cancel(UPLOAD_JOB_ID)
 }
 

--- a/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
@@ -15,6 +15,7 @@ import com.google.common.base.Optional
 import com.google.common.base.Stopwatch
 import com.openlattice.chronicle.ChronicleApi
 import com.openlattice.chronicle.ChronicleStudyApi
+import com.openlattice.chronicle.constants.Jobs.UPLOAD_JOB_ID
 import com.openlattice.chronicle.preferences.EnrollmentSettings
 import com.openlattice.chronicle.preferences.getDevice
 import com.openlattice.chronicle.preferences.getDeviceId
@@ -38,7 +39,6 @@ const val PRODUCTION = "https://api.openlattice.com/"
 const val BATCH_SIZE = 100 // 24 * 60 * 60 / 5 //17280
 const val LAST_UPDATED_SETTING = "com.openlattice.chronicle.upload.LastUpdated"
 const val UPLOAD_PERIOD_MILLIS = 15 * 60 * 1000L
-const val UPLOAD_JOB_ID = 5;
 
 class UploadJobService : JobService() {
     private val executor = Executors.newSingleThreadExecutor()
@@ -160,9 +160,9 @@ fun createRetrofitAdapter(baseUrl: String): Retrofit {
 }
 
 fun scheduleUploadJob(context: Context) {
-    if (!isJobServiceScheduled(context, UPLOAD_JOB_ID)) {
+    if (!isJobServiceScheduled(context, UPLOAD_JOB_ID.id)) {
         val serviceComponent = ComponentName(context, UploadJobService::class.java)
-        val jobBuilder = JobInfo.Builder(UPLOAD_JOB_ID, serviceComponent)
+        val jobBuilder = JobInfo.Builder(UPLOAD_JOB_ID.id, serviceComponent)
         jobBuilder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
         jobBuilder.setPeriodic(UPLOAD_PERIOD_MILLIS)
         jobBuilder.setPersisted(true)
@@ -173,6 +173,6 @@ fun scheduleUploadJob(context: Context) {
 
 fun cancelUploadJobScheduler (context: Context) {
     val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
-    jobScheduler.cancel(UPLOAD_JOB_ID)
+    jobScheduler.cancel(UPLOAD_JOB_ID.id)
 }
 

--- a/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
@@ -15,7 +15,6 @@ import com.google.common.base.Optional
 import com.google.common.base.Stopwatch
 import com.openlattice.chronicle.ChronicleApi
 import com.openlattice.chronicle.ChronicleStudyApi
-import com.openlattice.chronicle.data.ParticipationStatus
 import com.openlattice.chronicle.preferences.EnrollmentSettings
 import com.openlattice.chronicle.preferences.getDevice
 import com.openlattice.chronicle.preferences.getDeviceId
@@ -26,6 +25,7 @@ import com.openlattice.chronicle.services.sinks.OpenLatticeSink
 import com.openlattice.chronicle.storage.ChronicleDb
 import com.openlattice.chronicle.util.RetrofitBuilders
 import com.openlattice.chronicle.util.RetrofitBuilders.*
+import com.openlattice.chronicle.utils.Utils.isJobServiceScheduled
 import io.fabric.sdk.android.Fabric
 import org.joda.time.DateTime
 import retrofit2.Retrofit
@@ -160,13 +160,15 @@ fun createRetrofitAdapter(baseUrl: String): Retrofit {
 }
 
 fun scheduleUploadJob(context: Context) {
-    val serviceComponent = ComponentName(context, UploadJobService::class.java)
-    val jobBuilder = JobInfo.Builder(UPLOAD_JOB_ID, serviceComponent)
-    jobBuilder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
-    jobBuilder.setPeriodic(UPLOAD_PERIOD_MILLIS)
-    jobBuilder.setPersisted(true)
-    val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
-    jobScheduler.schedule(jobBuilder.build())
+    if (!isJobServiceScheduled(context, UPLOAD_JOB_ID)) {
+        val serviceComponent = ComponentName(context, UploadJobService::class.java)
+        val jobBuilder = JobInfo.Builder(UPLOAD_JOB_ID, serviceComponent)
+        jobBuilder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+        jobBuilder.setPeriodic(UPLOAD_PERIOD_MILLIS)
+        jobBuilder.setPersisted(true)
+        val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
+        jobScheduler.schedule(jobBuilder.build())
+    }
 }
 
 fun cancelUploadJobScheduler (context: Context) {

--- a/app/src/main/java/com/openlattice/chronicle/services/usage/UsageMonitoringJobService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/usage/UsageMonitoringJobService.kt
@@ -131,3 +131,8 @@ fun scheduleUsageMonitoringJob(context: Context) {
     val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
     jobScheduler.schedule(jobBuilder.build())
 }
+
+fun cancelUsageMonitoringJobScheduler(context :Context) {
+    val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
+    jobScheduler.cancel(MONITOR_USAGE_JOB)
+}

--- a/app/src/main/java/com/openlattice/chronicle/services/usage/UsageMonitoringJobService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/usage/UsageMonitoringJobService.kt
@@ -24,6 +24,7 @@ import com.openlattice.chronicle.services.upload.createRetrofitAdapter
 import com.openlattice.chronicle.storage.ChronicleDb
 import com.openlattice.chronicle.storage.QueueEntry
 import com.openlattice.chronicle.storage.StorageQueue
+import com.openlattice.chronicle.utils.Utils.isJobServiceScheduled
 import io.fabric.sdk.android.Fabric
 import java.util.*
 import java.util.concurrent.CountDownLatch
@@ -31,6 +32,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 const val UPLOAD_PERIOD_MILLIS = 15 * 60 * 1000L
+const val MONITOR_USAGE_JOB = 3;
 
 class UsageMonitoringJobService : JobService() {
     private val executor = Executors.newSingleThreadExecutor()
@@ -120,16 +122,16 @@ class UsageMonitoringJobService : JobService() {
     }
 }
 
-const val MONITOR_USAGE_JOB = 3;
-
 fun scheduleUsageMonitoringJob(context: Context) {
-    val serviceComponent = ComponentName(context, UsageMonitoringJobService::class.java)
-    val jobBuilder = JobInfo.Builder(MONITOR_USAGE_JOB, serviceComponent)
-    jobBuilder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
-    jobBuilder.setPeriodic(UPLOAD_PERIOD_MILLIS)
-    jobBuilder.setPersisted(true)
-    val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
-    jobScheduler.schedule(jobBuilder.build())
+    if (!isJobServiceScheduled(context, MONITOR_USAGE_JOB)) {
+        val serviceComponent = ComponentName(context, UsageMonitoringJobService::class.java)
+        val jobBuilder = JobInfo.Builder(MONITOR_USAGE_JOB, serviceComponent)
+        jobBuilder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+        jobBuilder.setPeriodic(UPLOAD_PERIOD_MILLIS)
+        jobBuilder.setPersisted(true)
+        val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
+        jobScheduler.schedule(jobBuilder.build())
+    }
 }
 
 fun cancelUsageMonitoringJobScheduler(context :Context) {

--- a/app/src/main/java/com/openlattice/chronicle/services/usage/UsageMonitoringJobService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/usage/UsageMonitoringJobService.kt
@@ -16,6 +16,7 @@ import com.google.common.collect.ImmutableMap
 import com.openlattice.chronicle.ChronicleApi
 import com.openlattice.chronicle.sensors.ChronicleSensor
 import com.openlattice.chronicle.sensors.PROPERTY_TYPES
+import com.openlattice.chronicle.constants.Jobs.MONITOR_USAGE_JOB_ID
 import com.openlattice.chronicle.sensors.UsageEventsChronicleSensor
 import com.openlattice.chronicle.sensors.UsageStatsChronicleSensor
 import com.openlattice.chronicle.serialization.JsonSerializer.serializeQueueEntry
@@ -32,7 +33,6 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 const val UPLOAD_PERIOD_MILLIS = 15 * 60 * 1000L
-const val MONITOR_USAGE_JOB = 3;
 
 class UsageMonitoringJobService : JobService() {
     private val executor = Executors.newSingleThreadExecutor()
@@ -123,9 +123,9 @@ class UsageMonitoringJobService : JobService() {
 }
 
 fun scheduleUsageMonitoringJob(context: Context) {
-    if (!isJobServiceScheduled(context, MONITOR_USAGE_JOB)) {
+    if (!isJobServiceScheduled(context, MONITOR_USAGE_JOB_ID.id)) {
         val serviceComponent = ComponentName(context, UsageMonitoringJobService::class.java)
-        val jobBuilder = JobInfo.Builder(MONITOR_USAGE_JOB, serviceComponent)
+        val jobBuilder = JobInfo.Builder(MONITOR_USAGE_JOB_ID.id, serviceComponent)
         jobBuilder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
         jobBuilder.setPeriodic(UPLOAD_PERIOD_MILLIS)
         jobBuilder.setPersisted(true)
@@ -136,5 +136,5 @@ fun scheduleUsageMonitoringJob(context: Context) {
 
 fun cancelUsageMonitoringJobScheduler(context :Context) {
     val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
-    jobScheduler.cancel(MONITOR_USAGE_JOB)
+    jobScheduler.cancel(MONITOR_USAGE_JOB_ID.id)
 }


### PR DESCRIPTION
The ParticipationStatusMonitoringService runs every 15 minutes. It fetches the participant status and:

Persists the status in the device's local storage.
If status != ENROLLED, stop currently scheduled usage monitoring and uploading services (if any are scheduled at the moment). Else, start services to monitor usage and upload data.
When the device is rebooted, usage monitoring and uploading services are only restarted if the persisted status == ENROLLED
This means that whenever the enrollment status of a user changes, the necessary effects (restarting or stopping collection & uploading services) will take place at most 15 minutes later.