### PR TITLE
Upgrade chronicle android app to Firebase Crashlytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /app/release
 /captures
 .externalNativeBuild
+google-services.json

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ apply from: "https://raw.githubusercontent.com/openlattice/gradles/master/repos.
 apply plugin: 'io.fabric'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     configurations.all {
         resolutionStrategy.force 'com.google.code.findbugs:jsr305:1.3.9'
     }
@@ -50,13 +50,13 @@ dependencies {
     }
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
     implementation('com.openlattice:chronicle-api:0.0.12') {
         exclude module: 'guava'
     }
-    implementation 'com.android.support:support-v4:27.1.1'
+    implementation 'com.android.support:support-v4:28.0.0'
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-guava:${jackson_version}") {
         exclude module: 'guava'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
         targetSdkVersion 28
         versionCode 10
         versionName "2020-06-29"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
@@ -50,13 +50,13 @@ dependencies {
     }
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support:design:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'com.google.android.material:material:1.1.0'
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
     implementation('com.openlattice:chronicle-api:0.0.12') {
         exclude module: 'guava'
     }
-    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-guava:${jackson_version}") {
         exclude module: 'guava'
     }
@@ -64,12 +64,12 @@ dependencies {
     implementation 'com.google.guava:guava:22.0-android'
     implementation 'org.dmfs:lib-recur:0.11.6'
 
-    implementation "android.arch.persistence.room:runtime:1.1.1"
-    implementation 'com.android.support.constraint:constraint-layout:1.1.0'
-    kapt "android.arch.persistence.room:compiler:1.1.1"
-    annotationProcessor "android.arch.persistence.room:compiler:1.1.1"
+    implementation 'androidx.room:room-runtime:2.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    kapt 'androidx.room:room-compiler:2.0.0'
+    annotationProcessor 'androidx.room:room-compiler:2.0.0'
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,14 @@
 apply plugin: 'com.android.application'
 
+apply plugin: 'com.google.gms.google-services'
+
 apply plugin: 'kotlin-android'
 
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply from: "https://raw.githubusercontent.com/openlattice/gradles/master/repos.gradle"
-apply plugin: 'io.fabric'
+
+apply plugin: 'com.google.firebase.crashlytics'
 
 android {
     compileSdkVersion 28
@@ -45,9 +48,9 @@ ext.jackson_version = '2.6.5'
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation('com.crashlytics.sdk.android:crashlytics:2.9.8@aar') {
-        transitive = true
-    }
+    implementation 'com.google.firebase:firebase-crashlytics:17.1.1'
+    implementation 'com.google.firebase:firebase-analytics:17.4.4'
+
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'

--- a/app/src/androidTest/java/com/openlattice/chronicle/ChronicleDbTests.kt
+++ b/app/src/androidTest/java/com/openlattice/chronicle/ChronicleDbTests.kt
@@ -1,15 +1,15 @@
 package com.openlattice.chronicle
 
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.openlattice.chronicle.storage.ChronicleDb
-import org.junit.BeforeClass
-import org.junit.Test
-import org.junit.runner.RunWith
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.openlattice.chronicle.storage.ChronicleDb
 import com.openlattice.chronicle.storage.QueueEntry
 import com.openlattice.chronicle.storage.StorageQueue
 import junit.framework.Assert
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
 
 
 @RunWith(AndroidJUnit4::class)
@@ -21,10 +21,10 @@ class ChronicleDbTests {
         @BeforeClass
         @JvmStatic
         fun setupChronicleDb() {
-            val appContext = InstrumentationRegistry.getTargetContext()
+            val appContext = InstrumentationRegistry.getInstrumentation().targetContext
             chronicleDb = Room.databaseBuilder(appContext, ChronicleDb::class.java!!, "chronicle").build()
             storageQueue = chronicleDb.queueEntryData()
-            chronicleDb.queueEntryData().deleteEntries( chronicleDb.queueEntryData().getNextEntries(1000) )
+            chronicleDb.queueEntryData().deleteEntries(chronicleDb.queueEntryData().getNextEntries(1000))
         }
 
     }
@@ -54,10 +54,10 @@ class ChronicleDbTests {
 
         ChronicleDbHolder.storageQueue.insertEntries(qeList);
         val actualArr = ChronicleDbHolder.storageQueue.getNextEntries(4)
-        Assert.assertEquals(4, actualArr.size )
-        Assert.assertEquals(qe1,actualArr[ 0 ])
-        Assert.assertEquals(qe2,actualArr[ 1 ])
-        Assert.assertEquals(qe3,actualArr[ 2 ])
-        Assert.assertEquals(qe4,actualArr[ 3 ])
+        Assert.assertEquals(4, actualArr.size)
+        Assert.assertEquals(qe1, actualArr[0])
+        Assert.assertEquals(qe2, actualArr[1])
+        Assert.assertEquals(qe3, actualArr[2])
+        Assert.assertEquals(qe4, actualArr[3])
     }
 }

--- a/app/src/androidTest/java/com/openlattice/chronicle/ChronicleDbTests.kt
+++ b/app/src/androidTest/java/com/openlattice/chronicle/ChronicleDbTests.kt
@@ -1,12 +1,12 @@
 package com.openlattice.chronicle
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.openlattice.chronicle.storage.ChronicleDb
 import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith
-import android.arch.persistence.room.Room
+import androidx.room.Room
 import com.openlattice.chronicle.storage.QueueEntry
 import com.openlattice.chronicle.storage.StorageQueue
 import junit.framework.Assert

--- a/app/src/androidTest/java/com/openlattice/chronicle/ChronicleUploadTests.kt
+++ b/app/src/androidTest/java/com/openlattice/chronicle/ChronicleUploadTests.kt
@@ -1,12 +1,13 @@
 package com.openlattice.chronicle
 
-import android.arch.persistence.room.Room
+import androidx.room.Room
 import android.os.Build
 import android.provider.Settings
-import android.support.test.InstrumentationRegistry
-import android.support.test.InstrumentationRegistry.getContext
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import android.util.Log
+import androidx.test.InstrumentationRegistry.getContext
+import androidx.test.InstrumentationRegistry.getTargetContext
 import com.fasterxml.jackson.datatype.guava.GuavaModule
 import com.google.common.base.Optional
 import com.google.common.base.Stopwatch
@@ -32,7 +33,7 @@ class ChronicleUploadTests {
         @BeforeClass
         @JvmStatic
         fun setupChronicleDb() {
-            val appContext = InstrumentationRegistry.getTargetContext()
+            val appContext = InstrumentationRegistry.getInstrumentation().targetContext
             chronicleDb = Room.databaseBuilder(appContext, ChronicleDb::class.java!!, "chronicle").build()
             storageQueue = chronicleDb.queueEntryData()
             chronicleDb.queueEntryData().deleteEntries(chronicleDb.queueEntryData().getNextEntries(1000))

--- a/app/src/androidTest/java/com/openlattice/chronicle/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/openlattice/chronicle/ExampleInstrumentedTest.kt
@@ -1,7 +1,7 @@
 package com.openlattice.chronicle
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/androidTest/java/com/openlattice/chronicle/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/openlattice/chronicle/ExampleInstrumentedTest.kt
@@ -18,7 +18,7 @@ class ExampleInstrumentedTest {
     @Test
     fun useAppContext() {
         // Context of the app under test.
-        val appContext = InstrumentationRegistry.getTargetContext()
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         assertEquals("com.openlattice.chronicle", appContext.packageName)
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,10 +79,6 @@
             android:name=".services.status.EnrollmentStatusMonitoringService"
             android:exported="true"
             android:permission="android.permission.BIND_JOB_SERVICE" />
-
-        <meta-data
-            android:name="io.fabric.ApiKey"
-            android:value="55f55312067c76e4837a8e502ed9744410192695" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/openlattice/chronicle/Enrollment.kt
+++ b/app/src/main/java/com/openlattice/chronicle/Enrollment.kt
@@ -4,7 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import android.view.View
 import android.widget.Button

--- a/app/src/main/java/com/openlattice/chronicle/MainActivity.kt
+++ b/app/src/main/java/com/openlattice/chronicle/MainActivity.kt
@@ -4,7 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.widget.TextView
 import com.crashlytics.android.Crashlytics
 import com.openlattice.chronicle.data.ParticipationStatus

--- a/app/src/main/java/com/openlattice/chronicle/MainActivity.kt
+++ b/app/src/main/java/com/openlattice/chronicle/MainActivity.kt
@@ -4,9 +4,8 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import androidx.appcompat.app.AppCompatActivity
 import android.widget.TextView
-import com.crashlytics.android.Crashlytics
+import androidx.appcompat.app.AppCompatActivity
 import com.openlattice.chronicle.data.ParticipationStatus
 import com.openlattice.chronicle.preferences.EnrollmentSettings
 import com.openlattice.chronicle.services.notifications.createNotificationChannel
@@ -14,8 +13,6 @@ import com.openlattice.chronicle.services.status.scheduleEnrollmentStatusJob
 import com.openlattice.chronicle.services.upload.getLastUpload
 import com.openlattice.chronicle.services.upload.scheduleUploadJob
 import com.openlattice.chronicle.services.usage.scheduleUsageMonitoringJob
-import io.fabric.sdk.android.Fabric
-
 
 const val LAST_UPLOAD_REFRESH_INTERVAL = 5000L
 
@@ -24,7 +21,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Fabric.with(this, Crashlytics())
         setContentView(R.layout.activity_main)
 
         // create notification channel

--- a/app/src/main/java/com/openlattice/chronicle/PermissionActivity.kt
+++ b/app/src/main/java/com/openlattice/chronicle/PermissionActivity.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.provider.Settings
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import android.view.View
 import android.widget.TextView

--- a/app/src/main/java/com/openlattice/chronicle/PermissionActivity.kt
+++ b/app/src/main/java/com/openlattice/chronicle/PermissionActivity.kt
@@ -6,19 +6,15 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.provider.Settings
-import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import android.view.View
 import android.widget.TextView
-import com.crashlytics.android.Crashlytics
-import io.fabric.sdk.android.Fabric
-
+import androidx.appcompat.app.AppCompatActivity
 
 class PermissionActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Fabric.with(this,  Crashlytics())
         setContentView(R.layout.activity_permission)
         if (hasUsageSettingPermission(this)) {
             doMainActivity(this)
@@ -56,7 +52,6 @@ class PermissionActivity : AppCompatActivity() {
                 })
     }
 }
-
 
 
 fun doMainActivity(context: Context) {

--- a/app/src/main/java/com/openlattice/chronicle/preferences/EnrollmentSettings.kt
+++ b/app/src/main/java/com/openlattice/chronicle/preferences/EnrollmentSettings.kt
@@ -35,7 +35,8 @@ class EnrollmentSettings(private val context: Context) {
         participantId = settings.getString(PARTICIPANT_ID, "")
         if (Utils.isValidUUID(studyIdString) && participantId.isNotBlank()) {
             studyId = UUID.fromString(studyIdString)
-            setCrashlyticsUser(studyId, participantId, getDeviceId(context))
+            setCrashlyticsUser(participantId)
+            setCrashlyticsState(studyId, getDeviceId(context))
         } else {
             studyId = INVALID_STUDY_ID
         }
@@ -113,10 +114,14 @@ fun getDevice(deviceId: String): AndroidDevice {
     return AndroidDevice(deviceId, Build.MODEL, Build.VERSION.CODENAME, Build.BRAND, Build.DISPLAY, Build.VERSION.SDK_INT.toString(), Build.PRODUCT, deviceId, Optional.absent())
 }
 
-fun setCrashlyticsUser(studyId: UUID, participantId: String, deviceId: String) {
+fun setCrashlyticsUser(participantId: String) {
     val crashlytics = FirebaseCrashlytics.getInstance()
 
     crashlytics.setUserId(participantId)
+}
+fun setCrashlyticsState(studyId: UUID, deviceId: String) {
+    val crashlytics = FirebaseCrashlytics.getInstance()
+
     crashlytics.setCustomKey(DEVICE_ID, deviceId)
     crashlytics.setCustomKey(STUDY_ID, studyId.toString())
 }

--- a/app/src/main/java/com/openlattice/chronicle/preferences/EnrollmentSettings.kt
+++ b/app/src/main/java/com/openlattice/chronicle/preferences/EnrollmentSettings.kt
@@ -4,15 +4,15 @@ import android.content.Context
 import android.os.Build
 import android.preference.PreferenceManager
 import android.provider.Settings
-import com.crashlytics.android.Crashlytics
 import com.google.common.base.Optional
 import com.google.common.collect.ImmutableMap
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.openlattice.chronicle.data.ParticipationStatus
 import com.openlattice.chronicle.serialization.JsonSerializer.deserializePropertyTypeIds
 import com.openlattice.chronicle.serialization.JsonSerializer.serializePropertyTypeIds
 import com.openlattice.chronicle.sources.AndroidDevice
 import com.openlattice.chronicle.utils.Utils
-import java.util.UUID
+import java.util.*
 
 const val PARTICIPANT_ID = "participantId"
 const val AWARENESS_NOTIFICATIONS_ENABLED = "notificationsEnabled"
@@ -65,13 +65,13 @@ class EnrollmentSettings(private val context: Context) {
         updateEnrolled()
     }
 
-    fun setAwarenessNotificationsEnabled(notificationsEnabled :Boolean) {
+    fun setAwarenessNotificationsEnabled(notificationsEnabled: Boolean) {
         settings.edit()
                 .putBoolean(AWARENESS_NOTIFICATIONS_ENABLED, notificationsEnabled)
                 .apply()
     }
 
-    fun getAwarenessNotificationsEnabled (): Boolean {
+    fun getAwarenessNotificationsEnabled(): Boolean {
         return settings.getBoolean(AWARENESS_NOTIFICATIONS_ENABLED, false)
     }
 
@@ -98,7 +98,7 @@ class EnrollmentSettings(private val context: Context) {
                 .apply()
     }
 
-    fun getParticipationStatus() :ParticipationStatus {
+    fun getParticipationStatus(): ParticipationStatus {
         return ParticipationStatus.valueOf(settings.getString(PARTICIPATION_STATUS, ParticipationStatus.UNKNOWN.toString()))
     }
 
@@ -113,7 +113,7 @@ fun getDevice(deviceId: String): AndroidDevice {
 }
 
 fun setCrashlyticsUser(studyId: UUID, participantId: String, deviceId: String) {
-    Crashlytics.setUserIdentifier(participantId)
-    Crashlytics.setUserEmail("$participantId@$studyId")
-    Crashlytics.setUserName(deviceId)
+    val crashlytics = FirebaseCrashlytics.getInstance()
+
+    crashlytics.setUserId(participantId)
 }

--- a/app/src/main/java/com/openlattice/chronicle/preferences/EnrollmentSettings.kt
+++ b/app/src/main/java/com/openlattice/chronicle/preferences/EnrollmentSettings.kt
@@ -17,6 +17,7 @@ import java.util.*
 const val PARTICIPANT_ID = "participantId"
 const val AWARENESS_NOTIFICATIONS_ENABLED = "notificationsEnabled"
 const val STUDY_ID = "studyId"
+const val DEVICE_ID = "deviceId"
 const val PARTICIPATION_STATUS = "participationStatus"
 const val PROPERTY_TYPE_IDS = "com.openlattice.PropertyTypeIds"
 
@@ -116,4 +117,6 @@ fun setCrashlyticsUser(studyId: UUID, participantId: String, deviceId: String) {
     val crashlytics = FirebaseCrashlytics.getInstance()
 
     crashlytics.setUserId(participantId)
+    crashlytics.setCustomKey(DEVICE_ID, deviceId)
+    crashlytics.setCustomKey(STUDY_ID, studyId.toString())
 }

--- a/app/src/main/java/com/openlattice/chronicle/receivers/lifecycle/NotificationsReceiver.kt
+++ b/app/src/main/java/com/openlattice/chronicle/receivers/lifecycle/NotificationsReceiver.kt
@@ -7,9 +7,9 @@ import android.content.Context
 import android.content.Intent
 import android.media.RingtoneManager
 import android.net.Uri
-import android.support.v4.app.NotificationCompat
-import android.support.v4.app.NotificationManagerCompat
-import android.support.v4.content.ContextCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import android.text.format.DateUtils
 import android.widget.RemoteViews
 import com.google.gson.Gson

--- a/app/src/main/java/com/openlattice/chronicle/services/notifications/NotificationsService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/notifications/NotificationsService.kt
@@ -8,9 +8,8 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import androidx.core.app.JobIntentService
 import android.util.Log
-import com.crashlytics.android.Crashlytics
+import androidx.core.app.JobIntentService
 import com.google.gson.Gson
 import com.openlattice.chronicle.R
 import com.openlattice.chronicle.constants.Jobs
@@ -18,7 +17,6 @@ import com.openlattice.chronicle.preferences.EnrollmentSettings
 import com.openlattice.chronicle.preferences.PARTICIPANT_ID
 import com.openlattice.chronicle.preferences.STUDY_ID
 import com.openlattice.chronicle.receivers.lifecycle.NotificationsReceiver
-import io.fabric.sdk.android.Fabric
 import org.dmfs.rfc5545.DateTime
 import org.dmfs.rfc5545.recur.RecurrenceRule
 import java.util.*
@@ -32,7 +30,6 @@ class NotificationsService : JobIntentService() {
 
     override fun onCreate() {
         super.onCreate()
-        Fabric.with(this, Crashlytics())
         settings = EnrollmentSettings(this)
     }
 

--- a/app/src/main/java/com/openlattice/chronicle/services/notifications/NotificationsService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/notifications/NotificationsService.kt
@@ -26,7 +26,12 @@ const val NOTIFICATIONS_ENABLED = "notificationsEnabled"
 const val NOTIFICATION_ENTRY = "notificationEntry"
 
 class NotificationsService : JobIntentService() {
-    private var settings: EnrollmentSettings = EnrollmentSettings(this)
+    private lateinit var settings: EnrollmentSettings
+
+    override fun onCreate() {
+        super.onCreate()
+        settings = EnrollmentSettings(this)
+    }
 
     companion object {
         fun enqueueWork(context: Context, intent: Intent) {

--- a/app/src/main/java/com/openlattice/chronicle/services/notifications/NotificationsService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/notifications/NotificationsService.kt
@@ -26,12 +26,7 @@ const val NOTIFICATIONS_ENABLED = "notificationsEnabled"
 const val NOTIFICATION_ENTRY = "notificationEntry"
 
 class NotificationsService : JobIntentService() {
-    private lateinit var settings: EnrollmentSettings
-
-    override fun onCreate() {
-        super.onCreate()
-        settings = EnrollmentSettings(this)
-    }
+    private var settings: EnrollmentSettings = EnrollmentSettings(this)
 
     companion object {
         fun enqueueWork(context: Context, intent: Intent) {

--- a/app/src/main/java/com/openlattice/chronicle/services/notifications/NotificationsService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/notifications/NotificationsService.kt
@@ -8,7 +8,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import android.support.v4.app.JobIntentService
+import androidx.core.app.JobIntentService
 import android.util.Log
 import com.crashlytics.android.Crashlytics
 import com.google.gson.Gson

--- a/app/src/main/java/com/openlattice/chronicle/services/status/EnrollmentStatusMonitoringService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/status/EnrollmentStatusMonitoringService.kt
@@ -8,7 +8,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.util.Log
-import com.crashlytics.android.Crashlytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.gson.Gson
 import com.openlattice.chronicle.ChronicleStudyApi
 import com.openlattice.chronicle.constants.Jobs.MONITOR_PARTICIPATION_STATUS_JOB_ID
@@ -28,7 +28,6 @@ import com.openlattice.chronicle.services.upload.createRetrofitAdapter
 import com.openlattice.chronicle.services.upload.scheduleUploadJob
 import com.openlattice.chronicle.services.usage.cancelUsageMonitoringJobScheduler
 import com.openlattice.chronicle.services.usage.scheduleUsageMonitoringJob
-import io.fabric.sdk.android.Fabric
 import org.apache.olingo.commons.api.edm.FullQualifiedName
 import java.util.*
 import java.util.concurrent.Executors
@@ -39,12 +38,12 @@ const val STATUS_CHECK_PERIOD_MILLIS = 15 * 60 * 1000L
 class EnrollmentStatusMonitoringService : JobService() {
     private val executor = Executors.newSingleThreadExecutor()
     private val chronicleStudyApi = createRetrofitAdapter(PRODUCTION).create(ChronicleStudyApi::class.java)
+    private val crashlytics = FirebaseCrashlytics.getInstance()
 
     private lateinit var enrollmentSettings: EnrollmentSettings;
 
     override fun onCreate() {
         super.onCreate()
-        Fabric.with(this, Crashlytics())
     }
 
     override fun onStopJob(p0: JobParameters?): Boolean {
@@ -73,8 +72,8 @@ class EnrollmentStatusMonitoringService : JobService() {
                 studyQuestionnaires = chronicleStudyApi.getStudyQuestionnaires(studyId)
 
             } catch (e: Exception) {
-                Crashlytics.log("caught exception: studyId: \"$studyId\" participantId: \"$participantId\"")
-                Crashlytics.logException(e)
+                crashlytics.log("caught exception: studyId: \"$studyId\" participantId: \"$participantId\"")
+                FirebaseCrashlytics.getInstance().recordException(e)
             }
             Log.i(javaClass.name, "Participation status: $participationStatus")
             Log.i(javaClass.name, "Study questionnaires: $studyQuestionnaires")

--- a/app/src/main/java/com/openlattice/chronicle/services/status/EnrollmentStatusMonitoringService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/status/EnrollmentStatusMonitoringService.kt
@@ -42,10 +42,6 @@ class EnrollmentStatusMonitoringService : JobService() {
 
     private lateinit var enrollmentSettings: EnrollmentSettings;
 
-    override fun onCreate() {
-        super.onCreate()
-    }
-
     override fun onStopJob(p0: JobParameters?): Boolean {
         Log.i(javaClass.name, "Enrollment status service stopped")
         executor.shutdown()

--- a/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
@@ -54,10 +54,6 @@ class UploadJobService : JobService() {
     private lateinit var deviceId: String
     private lateinit var dataSink: BrokerDataSink
 
-    override fun onCreate() {
-        super.onCreate()
-    }
-
     override fun onStopJob(params: JobParameters?): Boolean {
         executor.shutdown()
         executor.awaitTermination(1, TimeUnit.MINUTES)

--- a/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
@@ -4,7 +4,7 @@ import android.app.job.JobInfo
 import android.app.job.JobParameters
 import android.app.job.JobScheduler
 import android.app.job.JobService
-import android.arch.persistence.room.Room
+import androidx.room.Room
 import android.content.ComponentName
 import android.content.Context
 import android.preference.PreferenceManager

--- a/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/upload/UploadJobService.kt
@@ -34,7 +34,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-const val PRODUCTION = "http://10.0.2.2:8090"
+const val PRODUCTION = "https://api.openlattice.com/"
 const val BATCH_SIZE = 100 // 24 * 60 * 60 / 5 //17280
 const val LAST_UPDATED_SETTING = "com.openlattice.chronicle.upload.LastUpdated"
 const val UPLOAD_PERIOD_MILLIS = 15 * 60 * 1000L

--- a/app/src/main/java/com/openlattice/chronicle/services/usage/UsageEventsService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/usage/UsageEventsService.kt
@@ -5,7 +5,7 @@ import android.app.Notification
 import android.app.Notification.PRIORITY_LOW
 import android.app.NotificationChannel
 import android.app.PendingIntent
-import android.arch.persistence.room.Room
+import androidx.room.Room
 import android.content.Context
 import android.content.Intent
 import android.hardware.display.DisplayManager

--- a/app/src/main/java/com/openlattice/chronicle/services/usage/UsageEventsService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/usage/UsageEventsService.kt
@@ -13,7 +13,6 @@ import android.os.Build
 import android.os.Handler
 import android.util.Log
 import android.view.Display
-import com.crashlytics.android.Crashlytics
 import com.google.common.base.Stopwatch
 import com.google.common.collect.ImmutableMap
 import com.openlattice.chronicle.ChronicleApi
@@ -27,7 +26,6 @@ import com.openlattice.chronicle.services.upload.createRetrofitAdapter
 import com.openlattice.chronicle.storage.ChronicleDb
 import com.openlattice.chronicle.storage.QueueEntry
 import com.openlattice.chronicle.storage.StorageQueue
-import io.fabric.sdk.android.Fabric
 import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -56,7 +54,6 @@ class UsageEventsService : IntentService(USAGE_EVENTS_MONITORING_SERVICE) {
 
     override fun onCreate() {
         super.onCreate()
-        Fabric.with(this, Crashlytics())
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/app/src/main/java/com/openlattice/chronicle/services/usage/UsageEventsService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/usage/UsageEventsService.kt
@@ -51,11 +51,7 @@ class UsageEventsService : IntentService(USAGE_EVENTS_MONITORING_SERVICE) {
     private lateinit var chronicleDb: ChronicleDb
     private lateinit var storageQueue: StorageQueue
     private lateinit var sensors: Set<ChronicleSensor>
-
-    override fun onCreate() {
-        super.onCreate()
-    }
-
+    
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
         val notificationIntent = Intent(this, UsageEventsService::class.java)

--- a/app/src/main/java/com/openlattice/chronicle/services/usage/UsageEventsService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/usage/UsageEventsService.kt
@@ -51,7 +51,7 @@ class UsageEventsService : IntentService(USAGE_EVENTS_MONITORING_SERVICE) {
     private lateinit var chronicleDb: ChronicleDb
     private lateinit var storageQueue: StorageQueue
     private lateinit var sensors: Set<ChronicleSensor>
-    
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
         val notificationIntent = Intent(this, UsageEventsService::class.java)

--- a/app/src/main/java/com/openlattice/chronicle/services/usage/UsageMonitoringJobService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/usage/UsageMonitoringJobService.kt
@@ -4,21 +4,19 @@ import android.app.job.JobInfo
 import android.app.job.JobParameters
 import android.app.job.JobScheduler
 import android.app.job.JobService
-import androidx.room.Room
 import android.content.ComponentName
 import android.content.Context
 import android.hardware.display.DisplayManager
 import android.util.Log
 import android.view.Display
-import com.crashlytics.android.Crashlytics
+import androidx.room.Room
 import com.google.common.base.Stopwatch
 import com.google.common.collect.ImmutableMap
 import com.openlattice.chronicle.ChronicleApi
+import com.openlattice.chronicle.constants.Jobs.MONITOR_USAGE_JOB_ID
 import com.openlattice.chronicle.sensors.ChronicleSensor
 import com.openlattice.chronicle.sensors.PROPERTY_TYPES
-import com.openlattice.chronicle.constants.Jobs.MONITOR_USAGE_JOB_ID
 import com.openlattice.chronicle.sensors.UsageEventsChronicleSensor
-import com.openlattice.chronicle.sensors.UsageStatsChronicleSensor
 import com.openlattice.chronicle.serialization.JsonSerializer.serializeQueueEntry
 import com.openlattice.chronicle.services.upload.PRODUCTION
 import com.openlattice.chronicle.services.upload.createRetrofitAdapter
@@ -26,7 +24,6 @@ import com.openlattice.chronicle.storage.ChronicleDb
 import com.openlattice.chronicle.storage.QueueEntry
 import com.openlattice.chronicle.storage.StorageQueue
 import com.openlattice.chronicle.utils.Utils.isJobServiceScheduled
-import io.fabric.sdk.android.Fabric
 import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -46,11 +43,6 @@ class UsageMonitoringJobService : JobService() {
     private lateinit var chronicleDb: ChronicleDb
     private lateinit var storageQueue: StorageQueue
     private lateinit var sensors: Set<ChronicleSensor>
-
-    override fun onCreate() {
-        super.onCreate()
-        Fabric.with(this, Crashlytics())
-    }
 
     override fun onStartJob(params: JobParameters?): Boolean {
         executor.execute {
@@ -134,7 +126,7 @@ fun scheduleUsageMonitoringJob(context: Context) {
     }
 }
 
-fun cancelUsageMonitoringJobScheduler(context :Context) {
+fun cancelUsageMonitoringJobScheduler(context: Context) {
     val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
     jobScheduler.cancel(MONITOR_USAGE_JOB_ID.id)
 }

--- a/app/src/main/java/com/openlattice/chronicle/services/usage/UsageMonitoringJobService.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/usage/UsageMonitoringJobService.kt
@@ -4,7 +4,7 @@ import android.app.job.JobInfo
 import android.app.job.JobParameters
 import android.app.job.JobScheduler
 import android.app.job.JobService
-import android.arch.persistence.room.Room
+import androidx.room.Room
 import android.content.ComponentName
 import android.content.Context
 import android.hardware.display.DisplayManager

--- a/app/src/main/java/com/openlattice/chronicle/storage/ChronicleDb.kt
+++ b/app/src/main/java/com/openlattice/chronicle/storage/ChronicleDb.kt
@@ -1,7 +1,7 @@
 package com.openlattice.chronicle.storage
 
-import android.arch.persistence.room.Database
-import android.arch.persistence.room.RoomDatabase
+import androidx.room.Database
+import androidx.room.RoomDatabase
 
 @Database(entities = [QueueEntry::class], version = 1)
 abstract class ChronicleDb : RoomDatabase() {

--- a/app/src/main/java/com/openlattice/chronicle/storage/QueueEntry.kt
+++ b/app/src/main/java/com/openlattice/chronicle/storage/QueueEntry.kt
@@ -1,8 +1,8 @@
 package com.openlattice.chronicle.storage
 
-import android.arch.persistence.room.ColumnInfo
-import android.arch.persistence.room.Entity
-import android.arch.persistence.room.Index
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
 import java.util.*
 
 @Entity(tableName = "dataQueue",

--- a/app/src/main/java/com/openlattice/chronicle/storage/StorageQueue.kt
+++ b/app/src/main/java/com/openlattice/chronicle/storage/StorageQueue.kt
@@ -1,9 +1,9 @@
 package com.openlattice.chronicle.storage
 
-import android.arch.persistence.room.Dao
-import android.arch.persistence.room.Delete
-import android.arch.persistence.room.Insert
-import android.arch.persistence.room.Query
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
 
 /*
  * Since database will return sorted elements, we use a list to preserve order, even though items

--- a/app/src/main/java/com/openlattice/chronicle/utils/Utils.kt
+++ b/app/src/main/java/com/openlattice/chronicle/utils/Utils.kt
@@ -4,7 +4,7 @@ import android.app.job.JobScheduler
 import android.content.Context
 import android.content.pm.PackageManager
 import android.net.Uri
-import com.crashlytics.android.Crashlytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.openlattice.chronicle.constants.NotificationType
 import com.openlattice.chronicle.services.notifications.NotificationEntry
 import java.util.*
@@ -16,7 +16,7 @@ object Utils {
         val uuidAsString = uuid.toString()
         uuidAsString == possibleUUID
     } catch (e: IllegalArgumentException) {
-        Crashlytics.logException(e)
+        FirebaseCrashlytics.getInstance().recordException(e)
         false
     }
 

--- a/app/src/main/res/layout/activity_enrollment.xml
+++ b/app/src/main/res/layout/activity_enrollment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -94,4 +94,4 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/statusMessage" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/linearLayout"
@@ -84,4 +84,4 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/lastUploadHeader" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_permission.xml
+++ b/app/src/main/res/layout/activity_permission.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -28,4 +28,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -5,14 +5,15 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
+        classpath 'com.google.gms:google-services:4.3.3'
         classpath 'com.android.tools.build:gradle:3.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'io.fabric.tools:gradle:1.+'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.2.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
PR:

Upgrade to the new Firebase Crashlytics SDK from Fabric Crashlytics SDK
1) Migrate to AndroidX (on Android Studio select Refactor -> Migrate to AndroidX)
2) Add Firebase Android config file to app module
3) Add necessary dependencies
4) Update code (Remove `Fabric.with()` calls etc) 

Instructions can be found here: https://firebase.google.com/docs/crashlytics/upgrade-sdk?platform=android