### PR TITLE
Fix local project build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,5 @@
 apply plugin: 'com.android.application'
 
-apply plugin: 'com.google.gms.google-services'
-
 apply plugin: 'kotlin-android'
 
 apply plugin: 'kotlin-android-extensions'


### PR DESCRIPTION
PR: 

Local build was failing with this error:
```
Execution failed for task ':app:processDebugGoogleServices'.
```

According to the recommendation on StackOverflow (https://stackoverflow.com/questions/33572465/gradle-errorexecution-failed-for-task-appprocessdebuggoogleservices) the solution to this is deleting `apply plugin: 'com.google.gms.google-services'` since `com.android.application` already has same package.
