### PR TITLE
bump up work manager version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '1.6.0'
-    ext.work_version = "2.4.0"
+    ext.work_version = "2.7.1"
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
PR fixes an issue that was causing android 12 to crash
```Targeting S+ (version 31 and above) requires that one of
FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if
some functionality depends on the PendingIntent being mutable, e.g. if
it needs to be used with inline replies or bubbles.
```